### PR TITLE
Support java 6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.brunchboy/protobuf "0.8.3-SNAPSHOT"
+(defproject org.flatland/protobuf "0.8.3"
   :description "Clojure-protobuf provides a clojure interface to Google's protocol buffers."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
@@ -8,7 +8,7 @@
                  [org.flatland/schematic "0.1.0"]
                  [org.flatland/io "0.3.0"]
                  [ordered-collections "0.4.0"]]
-  :plugins [[org.clojars.brunchboy/lein-protobuf "0.4.3-SNAPSHOT"]]
+  :plugins [[lein-protobuf "0.4.3"]]
   :aliases {"testall" ["with-profile" "dev,default:dev,1.3,default:dev,1.5,default" "test"]}
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.0-master-SNAPSHOT"]]}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.flatland/protobuf "0.8.2"
+(defproject org.clojars.brunchboy/protobuf "0.8.3-SNAPSHOT"
   :description "Clojure-protobuf provides a clojure interface to Google's protocol buffers."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
@@ -8,7 +8,7 @@
                  [org.flatland/schematic "0.1.0"]
                  [org.flatland/io "0.3.0"]
                  [ordered-collections "0.4.0"]]
-  :plugins [[lein-protobuf "0.4.2"]]
+  :plugins [[org.clojars.brunchboy/lein-protobuf "0.4.3-SNAPSHOT"]]
   :aliases {"testall" ["with-profile" "dev,default:dev,1.3,default:dev,1.5,default" "test"]}
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.0-master-SNAPSHOT"]]}
@@ -17,4 +17,5 @@
                                        :snapshots true
                                        :releases {:checksum :fail :update :always}}}
   :checksum-deps true
+  :javac-options ["-target" "1.6" "-source" "1.6"]
   :java-source-paths ["src"])


### PR DESCRIPTION
Even though Clojure itself generates classes that are compatible back to Java 6, lein-protobuf is compiling to whatever JVM version happens to be installed on the developer's machine. This is a problem because I want to be able to use protobuf in my open-source lighting controller [Afterglow](https://github.com/brunchboy/afterglow#afterglow), and be able to host that within [Cycling ‘74’s Max](https://cycling74.com/), which only supports the legacy Apple Java 6 implementation on the Mac.

This change tells Leiningen to run `javac` with arguments that create Java 6 compatible class files even if it is being run with a newer JDK.

> **This pull request depends on my related pull request to `lein-protobuf` being accepted before it can be applied.**
